### PR TITLE
undo hydration fixes

### DIFF
--- a/src/app/(website)/_root/hero/content.tsx
+++ b/src/app/(website)/_root/hero/content.tsx
@@ -1,7 +1,7 @@
 import { HomepageDataQueries } from '@/sanity/lib/queries'
 import StyledPortableText from '../../../../components/styled-portable-text'
 
-export default async function Content(props: {
+export default function Content(props: {
   claim: NonNullable<HomepageDataQueries>
 }) {
   if (!props.claim.claim) {


### PR DESCRIPTION
undo hydration fixes. they break text blocks, but only on prod. 
made sure component is not an async component, as it can be a server or a client component.